### PR TITLE
Path fixes due for two repos 

### DIFF
--- a/src/autoval_ssd/lib/utils/disk_utils.py
+++ b/src/autoval_ssd/lib/utils/disk_utils.py
@@ -15,8 +15,6 @@ from autoval.lib.utils.autoval_exceptions import TestError
 from autoval.lib.utils.autoval_log import AutovalLog
 from autoval.lib.utils.autoval_thread import AutovalThread
 from autoval.lib.utils.autoval_utils import AutovalUtils
-from autoval.lib.utils.golden_config_check import GoldenConfigCheck
-
 from autoval_ssd.lib.utils.filesystem_utils import FilesystemUtils
 from autoval_ssd.lib.utils.sg_utils import SgUtils
 
@@ -243,7 +241,7 @@ class DiskUtils:
         return devices
 
     @staticmethod
-    def get_block_devices(host, exclude_boot_drive: bool = True):
+    def get_block_devices(host, exclude_boot_drive: bool = True, boot_drive_physical_location: str = ""):
         """
         Return a list of block devices on the system
         @return String[]: e.g. [sda, sdb, sdc ...]
@@ -254,7 +252,14 @@ class DiskUtils:
         if not drives:
             raise TestError("Not able to match block devices from lsblk output")
         if exclude_boot_drive:
-            boot_drive = DiskUtils.get_boot_drive(host)
+            if boot_drive_physical_location:
+                boot_drive: str = DiskUtils.get_block_from_physical_location(
+                    host,
+                    [boot_drive_physical_location],
+                    DiskUtils.get_block_devices_info(host),
+                )
+            else:
+                boot_drive = DiskUtils.get_boot_drive(host)
             if boot_drive:
                 drives.remove(boot_drive)
         return drives
@@ -343,7 +348,7 @@ class DiskUtils:
         return False
 
     @staticmethod
-    def get_boot_drive(host) -> str:
+    def get_boot_drive(host, boot_drive_physical_location: str = "") -> str:
         """
         This method will return the boot drive in the host
         @param Host host : Host Object
@@ -382,10 +387,9 @@ class DiskUtils:
                     return boot_drive
         # If the boot drive is not mounted or doesn't have boot-sectors.
         # Filtering the boot drive based on the BOM file
-        physical_location = GoldenConfigCheck().get_boot_drive_from_golden_config(host)
-        if physical_location:
+        if boot_drive_physical_location:
             boot_drive = DiskUtils.get_block_from_physical_location(
-                host, physical_location, lsblk["blockdevices"]
+                host, [boot_drive_physical_location], lsblk["blockdevices"]
             )
         return boot_drive
 

--- a/src/autoval_ssd/lib/utils/fio_runner.py
+++ b/src/autoval_ssd/lib/utils/fio_runner.py
@@ -133,6 +133,7 @@ class FioRunner(TestUtilsBase):
         self.enable_performance_metrics_validation = args.get(
             "enable_performance_metrics_validation", False
         )
+        self.boot_drive_physical_location = args.get("boot_drive_physical_location", "")
         fio_timeout = args.get("fio_timeout", 86400)
         try:
             self.fio_timeout = int(fio_timeout)
@@ -733,7 +734,9 @@ class FioRunner(TestUtilsBase):
                 drives=self.drives,
             )
         if self.boot_drive is None:
-            self.boot_drive = DiskUtils.get_boot_drive(self.host)
+            self.boot_drive = DiskUtils.get_boot_drive(
+                self.host, self.boot_drive_physical_location
+            )
         by_model = StorageUtils.group_drive_by_attr("model", self.drives)
         write_iops = {}
         read_iops = {}

--- a/src/autoval_ssd/lib/utils/sed_util.py
+++ b/src/autoval_ssd/lib/utils/sed_util.py
@@ -2,17 +2,14 @@
 
 # pyre-strict
 import re
-from typing import List, Tuple, TYPE_CHECKING
+from typing import List, Tuple
+from autoval.lib.host.host import Host
 
 from autoval.lib.utils.autoval_exceptions import TestError
 from autoval.lib.utils.autoval_utils import AutovalLog, AutovalUtils
 
 from autoval_ssd.lib.utils.disk_utils import DiskUtils
-from autoval_ssd.lib.utils.storage.nvme.nvme_drive import OwnershipStatus
-
-if TYPE_CHECKING:
-    from autoval.lib.host.host import Host
-    from autoval_ssd.lib.utils.storage.nvme.nvme_drive import NVMeDrive
+from autoval_ssd.lib.utils.storage.nvme.nvme_drive import NVMeDrive, OwnershipStatus
 
 
 class SedUtils:

--- a/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
+++ b/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
@@ -151,10 +151,10 @@ class NVMeDrive(Drive):
         return validate_config
 
     def get_target_path(self) -> str:
-    """
-    Returns the path of the target path which is used to get the cfg path in the autoval-oss
-    """
-    # Get the absolute path of the current file
+        """
+        Returns the path of the target path which is used to get the cfg path in the autoval-oss
+        Get the absolute path of the current file
+        """
         target_path = ""
         current_file_path = os.path.abspath(__file__)
         try:

--- a/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
+++ b/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
@@ -32,6 +32,7 @@ from autoval_ssd.lib.utils.storage.nvme.nvme_utils import NVMeUtils
 DEFAULT_VALIDATE_CONFIG = "nvme_validate.json"
 
 
+
 def _strip_white_spaces_from_keys(mapping: dict) -> None:
     """
     Recursively remove white spaces from key names of a dictionary in place
@@ -136,18 +137,18 @@ class NVMeDrive(Drive):
         config = {}
         self.cfg_dir = self._get_config_dir(config_file)
         relative_cfg_file_path = os.path.join(self.cfg_dir, config_file)
-        relative_cfg_file_path = "cfg/" + relative_cfg_file_path
-        content = GenericUtils.read_resource_cfg(
-            file_path=relative_cfg_file_path,
-            module="autoval_ssd",
-            autoval_oss_path=self.get_target_path(),
-        )
+        relative_cfg_file_path = "/cfg/" + relative_cfg_file_path
+        abs_path = self.get_target_path()
+        nvme_cfg_path = abs_path + relative_cfg_file_path
+        AutovalLog.log_info(f"The file path for Nvme config {nvme_cfg_path}")
+        content = FileActions.read_data(nvme_cfg_path, json_file=True)
+        AutovalLog.log_info(f"Reading content {content} from cfg directory")
         config.update(content["nvme"])
         self.get_smart_log_keys()
         config = self._flatten_validate_config_dict(config)
         validate_config = {
-            key: config[key] for key in self.smart_log_keys if key in config
-        }
+                key: config[key] for key in self.smart_log_keys if key in config
+                }
         return validate_config
 
     def get_target_path(self) -> str:

--- a/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
+++ b/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
@@ -155,16 +155,16 @@ class NVMeDrive(Drive):
     Returns the path of the target path which is used to get the cfg path in the autoval-oss
     """
     # Get the absolute path of the current file
-    target_path = ""
-    current_file_path = os.path.abspath(__file__)
-    try:
-        pattern = r"^(/.*?)/lib"
-        match = re.search(pattern, current_file_path)
-        if match:
-            target_path = match.group(1)
-    except Exception:
-        raise AutovalFileNotFound("The required file path is not found")
-    return target_path
+        target_path = ""
+        current_file_path = os.path.abspath(__file__)
+        try:
+            pattern = r"^(/.*?)/lib"
+            match = re.search(pattern, current_file_path)
+            if match:
+                target_path = match.group(1)
+        except Exception:
+            raise AutovalFileNotFound("The required file path is not found")
+        return target_path
 
     def _get_config_dir(self, ext_file) -> str:
         """

--- a/src/autoval_ssd/lib/utils/storage/storage_test_base.py
+++ b/src/autoval_ssd/lib/utils/storage/storage_test_base.py
@@ -232,9 +232,9 @@ class StorageTestBase(TestBase):
         if self.original_test_control_drives:
             drive_list = self.original_test_control_drives
         else:
-           drive_list = DiskUtils.get_block_devices(
+            drive_list = DiskUtils.get_block_devices(
                 self.host,
-                boot_drive_physical_location=self.boot_drive_physical_location,
+            boot_drive_physical_location=self.boot_drive_physical_location,
             )
 
         if boot_drive != "" and boot_drive != "rootfs":

--- a/src/autoval_ssd/lib/utils/storage/storage_test_base.py
+++ b/src/autoval_ssd/lib/utils/storage/storage_test_base.py
@@ -232,7 +232,10 @@ class StorageTestBase(TestBase):
         if self.original_test_control_drives:
             drive_list = self.original_test_control_drives
         else:
-            drive_list = DiskUtils.get_block_devices(self.host)
+           drive_list = DiskUtils.get_block_devices(
+                self.host,
+                boot_drive_physical_location=self.boot_drive_physical_location,
+            )
 
         if boot_drive != "" and boot_drive != "rootfs":
             drive_list.append(boot_drive)

--- a/src/autoval_ssd/tests/nvme_cli/nvme_cli.rst
+++ b/src/autoval_ssd/tests/nvme_cli/nvme_cli.rst
@@ -27,6 +27,6 @@ Test Description
         validate capacity
   **
 
-Common Objective of drive_data_integrity test
+Common Objective of nvme_cli test
 ---------------------------------------------
 Verify that a DUT with SSD NVMe can support the NVMe Spec commands.


### PR DESCRIPTION
The absence of the golden_config.json file resulted in failures in picking boot drive  and hence it was addressed by implementing an alternative solution to obtain the boot drive information using the boot_drive_physical_location 

The current implementation of get_resource_cfg() does not support the ocp-diag_autoval-ssd package due to the following reason: When installing packages using pip, the default installation location for packages in Python 3.9 on Linux systems is /usr/local/lib/python3.9/site-packages/. Consequently, the pkg_resources.resource_filename() method returns a path to the package resources within this directory, which differs from the actual location of the configuration file nvme_validate.json stored in the autoval-ssd folder.
To address this issue, we have implemented a fix so that the path is picked from the same file

Also addressed, removing golden config changes in fio_runner and disk_utils 

These changes were done and tested.

Pass Logs:

(env) [root@odcctrl-1 ocp-diag-autoval-ssd]# python -m autoval.autoval_test_runner autoval_ssd.tests.nvme_cli.nvme_cli --config /home/aarthi/hosts.json --test_control ~/bin/ocp-diag-autoval-ssd/autoval_ssd/tests/nvme_cli/control.json
[06/06/2024 18:54:53] - Logging to /autoval/results/FE80::E42:A1FF:FEF2:2E12%enp94s0np0/NvmeCli/2024-06-06_18-54-53
[06/06/2024 18:54:53] - Runtime cmdlog location: /autoval/results/FE80::E42:A1FF:FEF2:2E12%enp94s0np0/NvmeCli/2024-06-06_18-54-53/cmdlog.log
[06/06/2024 18:54:53] - Starting test NvmeCli on FE80::E42:A1FF:FEF2:2E12%enp94s0np0
[06/06/2024 18:54:59] - ocp-smart-add-log is not supported on the drive nvme0n1 (HFS512GD9TNG-62A0A).
[06/06/2024 18:54:59] - Drive info summary:
[06/06/2024 18:54:59] - Manufacturer
[06/06/2024 18:54:59] - 	GenericNVMe: nvme0n1
[06/06/2024 18:54:59] - Model
[06/06/2024 18:54:59] - 	HFS512GD9TNG-62A0A: nvme0n1
[06/06/2024 18:54:59] - Type
[06/06/2024 18:54:59] - 	DriveType.SSD: nvme0n1
[06/06/2024 18:54:59] - Interface
[06/06/2024 18:54:59] - 	DriveInterface.NVME: nvme0n1
[06/06/2024 18:54:59] - Firmware_version
[06/06/2024 18:54:59] - 	80004E00: nvme0n1
[06/06/2024 18:54:59] - Fetching test drives.
[06/06/2024 18:54:59] - Available drives: [nvme0n1], Drives under test: [nvme0n1]
[06/06/2024 18:54:59] - Removing all mounted path
[06/06/2024 18:54:59] - Validating umount all drives
[06/06/2024 18:54:59] - PASSED - 1 - Validating the unmount on drives - Actual: [[]] - Validation: [isEmptyList] - Expected: [[]]
[06/06/2024 18:54:59] - Disabling write_cache
[06/06/2024 18:54:59] - Validating write_cache
[06/06/2024 18:54:59] - Write_cache disabling may not supported on boot drive
[06/06/2024 18:54:59] - No degraded drives are present.
[06/06/2024 18:54:59] - Collecting drive data.
[06/06/2024 18:54:59] - ocp-smart-add-log is not supported on the drive nvme0n1 (HFS512GD9TNG-62A0A).
[06/06/2024 18:54:59] - PASSED - 3 - Test drives list is not empty - Actual: [[nvme0n1]] - Validation: [isNonEmptyList] - Expected: [Non Empty List]
[06/06/2024 18:55:00] - Warning: Did not find UnsuppReg in lspci output, check the drive nvme0n1
[06/06/2024 18:55:00] - ocp-smart-add-log is not supported on the drive nvme0n1 (HFS512GD9TNG-62A0A).
[06/06/2024 18:55:00] - ocp-smart-add-log is not supported on the drive nvme0n1 (HFS512GD9TNG-62A0A).
[06/06/2024 18:55:00] - umount and remove raid devices
[06/06/2024 18:55:00] - Removing drive's partitions
[06/06/2024 18:55:05] - Skipping BMC-based SSD drive health checking
[06/06/2024 18:55:05] - PASSED - 4 - Run 'nvme id-ctrl /dev/nvme0n1 -H | grep -v fguid' - Actual: [None] - Validation: [isNotException] - Expected: [None]
[06/06/2024 18:55:05] - nvme0n1 drive on the DUT does not support crypto erase 
[06/06/2024 18:55:05] - Skip Crypto Erase validation on boot drive and drives which dont support it
[06/06/2024 18:55:05] - Test to run NVME Cli commands
[06/06/2024 18:55:06] - Running NVME version 1.11.2
[06/06/2024 18:55:06] - PASSED - 5 - Check drive nvme is write mode enabled nvme0n1 - Actual: [True] - Validation: [isTrue] - Expected: [True]
[06/06/2024 18:55:06] - PASSED - 6 - Run 'nvme fw-log /dev/nvme0n1 -o json' - Actual: [None] - Validation: [isNotException] - Expected: [None]
[06/06/2024 18:55:06] - PASSED - 7 - {'nvme0n1': {'Active Firmware Slot (afi)': 1, 'Firmware Rev Slot 1': '3472351403151732792 (80004E00)'}} - Actual: [1] - Validation: [isGreater] - Expected: [0]
[06/06/2024 18:55:06] - PASSED - 8 - Asserting device names match - Actual: [['nvme0n1']] - Validation: [isEqual] - Expected: [['nvme0n1']]
[06/06/2024 18:55:06] - umount and remove raid devices
[06/06/2024 18:55:06] - Removing drive's partitions
[06/06/2024 18:55:11] - Removing all mounted path
[06/06/2024 18:55:11] - Validating umount all drives
[06/06/2024 18:55:11] - PASSED - 9 - Validating the unmount on drives - Actual: [[]] - Validation: [isEmptyList] - Expected: [[]]
[06/06/2024 18:55:12] - PASSED - 10 - Check available drives against initial list. - Actual: [['nvme0n1']] - Validation: [isEqual] - Expected: [['nvme0n1']]
[06/06/2024 18:55:12] - ocp-smart-add-log is not supported on the drive nvme0n1 (HFS512GD9TNG-62A0A).
[06/06/2024 18:55:13] - ocp-smart-add-log is not supported on the drive nvme0n1 (HFS512GD9TNG-62A0A).
[06/06/2024 18:55:13] - ocp-smart-add-log is not supported on the drive nvme0n1 (HFS512GD9TNG-62A0A).
[06/06/2024 18:55:13] - Converting storage data for config check
[06/06/2024 18:55:13] - ocp-smart-add-log is not supported on the drive nvme0n1 (HFS512GD9TNG-62A0A).
[06/06/2024 18:55:13] - saving config results from storage_test_base at /autoval/results/FE80::E42:A1FF:FEF2:2E12%enp94s0np0/NvmeCli/2024-06-06_18-54-53/config_results.json
[06/06/2024 18:55:14] - Unable to get the serial number
[06/06/2024 18:55:14] - Failed to collect test manifest data
[06/06/2024 18:55:14] - saving results at /autoval/results/FE80::E42:A1FF:FEF2:2E12%enp94s0np0/NvmeCli/2024-06-06_18-54-53/test_results.json
[06/06/2024 18:55:14] - saving test steps at /autoval/results/FE80::E42:A1FF:FEF2:2E12%enp94s0np0/NvmeCli/2024-06-06_18-54-53/test_steps.json
[06/06/2024 18:55:14] - +++Test Finished:
Test Summary: NvmeCli 
    Test to validate if NVME 1.2.1 spec commands are supported
    Validations done on all the NVME drives:
        Get the controller properties,
        Get the Firmware Log,
        Check Crypto Erase Support,
        Get Error Log Entries,
        Log the properties of the specified namespace,
        Get the operating parameters of the specified controller,
        identified by the Feature Identifier,
        Get Vendor Specific Internal Logs,
        Retrieve Command Effects Log.
        Get Vendor Specific drive up time,
        Get Smart log,
        Get/Set Power mode.
        validate capacity Parameters: Drive type: ssd, Drive interface: nvme, Check crypto erase: True
Passed Steps: 18
Warning Steps: 0
Failed Steps: 0
Test Result : TEST PASSED