### PR TITLE
Handle errors when boot_drive_physical_location is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ Example:
     ]
 }
 ```
+### Update control.json file with boot drive physical location
+Every test has its control parameters provided by the `control.json` file located in the same directory as the test module.
+`boot_drive_physical_location` should be passed as a test control parameter using the following *BDF* format.
+```
+Format:  <PCI domain>:<bus>:<device>.<function>
+```
+Example:
+```json
+  "boot_drive_physical_location": "0000:64:00.0"
+```
+
 ### Test Execution
 Now that you have a `hosts.json` file, you can run a test as follows.
 ```bash

--- a/src/autoval_ssd/tests/nvme_cli/control.json
+++ b/src/autoval_ssd/tests/nvme_cli/control.json
@@ -1,5 +1,6 @@
 {
   "drive_type": "ssd",
   "drive_interface": "nvme",
-  "include_boot_drive": true
+  "include_boot_drive": true,
+  "boot_drive_physical_location": "0000:01:00.0"
 }


### PR DESCRIPTION
This change set is concerned with the code that excludes the boot drive from set of drives to be tested (based on test control parameters).
Before this diff
If boot_drive_physical_location was not specified in test control, and test would fail with error even on systems where a boot drive could not be detected.  
After this fix,
When trying to select the boot drive to be excluded, we first try to use boot_drive_physical_location test control param.  If the param is not set (or doesn't work) then we try to autodetect the boot drive instead.
We generate user friendly errors (identifying the problem and providing a solution) in cases where the test control param was incorrect or we cannot detect the boot drive.

As well readme is enhanced with these details.
