### PR TITLE
Jobfile missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,4 @@ publish = ["build", "twine"]
 "Source" = "https://github.com/opencomputeproject/ocp-diag-autoval-ssd"
 
 [tool.setuptools.package-data]
-"*" = ["*.json"]
-
+"*" = ["*.json", "*.fio"]

--- a/src/autoval_ssd/lib/utils/fio_runner.py
+++ b/src/autoval_ssd/lib/utils/fio_runner.py
@@ -447,10 +447,8 @@ class FioRunner(TestUtilsBase):
             replace = {}
         if not files and not drives:
             drives = self.get_drives(drive_type, drive_interface, drives)
-        templ_path = FileActions.get_resource_file_path(
-            os.path.join(LIB_PATH, templ_filename), "autoval_ssd"
-        )
-        content = FileActions.read_data(templ_path)
+        templ_file = os.path.join(self.get_jobfile_templates_path(), templ_filename)
+        content = FileActions.read_data(templ_file)
         _size = ""
         for key, value in replace.items():
             regex = re.compile(f"={key}", re.MULTILINE)
@@ -529,6 +527,29 @@ class FioRunner(TestUtilsBase):
             self.host.put_file(job_file, dest_job_file)
         AutovalLog.log_info("Job file used: %s" % dest_job_file)
         return dest_job_file
+        
+    def get_jobfile_templates_path(self) -> str:
+        """
+        Return path to the jobfile_templates/ directory.
+
+        Returns:
+            The path to the jobfile_templates/ directory.
+
+        Raises:
+            TestError: jobfile_templates/ directory can't be detected because the current
+            file is not located in a path with a lib/ subdirectory.
+        """
+        current_file_path = os.path.abspath(__file__)
+        pattern = r"^(/.*?/lib)"
+        match = re.search(pattern, current_file_path)
+        if not match:
+            raise TestError(
+                "Unable to determine path to fio jobfile_templates directory.\n"
+                f"Directory 'lib/' missing from path '{current_file_path}' of current file '{__file__}'.\n"
+                "This is likely caused by an AutoVal build or packaging issue."
+            )
+        lib_path = match.group(1)
+        return os.path.join(lib_path, "utils/jobfile_templates")
 
     def _create_file(self, device: str, _file: str, _size: str):
         """


### PR DESCRIPTION
Issue 1:
After building ocp-diag-autoval-ssd repository in the tar files (./dist/ocptv_autoval_ssd-0.0.1.tar.gz), jobfile_templates folder consisting of all .fio files was missing , which is actually present as part of the code base
Solution:
The .fio extension wasn't added in the file pyproject.toml. The python files gets built, but since jobfile_templates isn't a .py file these needs to be explicitly mentioned in pyproject.toml.
Issue 2:
After Issue 1 was addressed observed that since FileActions.get_resource_file_path exists in autoval repository instead of autoval_ssd the absolute path being picked didn't match the required path.
Solution:
Hence added a function to get the jobfile template path

Test works fine in both DC and lab mode
Logs:
07/18/2024 22:53:55] - Starting test DriveCacheCheck on rtptest023.ldc1
[07/18/2024 22:54:30] - ocp-smart-add-log is not supported on the drive nvme0n1 (WDC CL SN720 SDAQNTW-512G-1020).
[07/18/2024 22:54:30] - Drive info summary:
[07/18/2024 22:54:31] - Manufacturer
[07/18/2024 22:54:31] -         GenericNVMe: nvme0n1
[07/18/2024 22:54:31] - Model
[07/18/2024 22:54:31] -         WDC CL SN720 SDAQNTW-512G-1020: nvme0n1
[07/18/2024 22:54:31] - Type
[07/18/2024 22:54:31] -         DriveType.SSD: nvme0n1
[07/18/2024 22:54:31] - Interface
[07/18/2024 22:54:31] -         DriveInterface.NVME: nvme0n1
[07/18/2024 22:54:31] - Firmware_version
[07/18/2024 22:54:31] -         10106120: nvme0n1
[07/18/2024 22:54:31] - Fetching test drives.
[07/18/2024 22:54:32] - Available drives: [nvme0n1], Drives under test: [nvme0n1]
[07/18/2024 22:54:32] - Removing all mounted path
[07/18/2024 22:54:32] - Validating umount all drives
[07/18/2024 22:54:32] - PASSED - 1 - Validating the unmount on drives - Actual: [[]] - Validation: [isEmptyList] - Expected: [[]]
[07/18/2024 22:54:32] - Disabling write_cache
[07/18/2024 22:54:33] - Validating write_cache
[07/18/2024 22:54:34] - Write_cache disabling may not supported on boot drive
[07/18/2024 22:54:35] - No degraded drives are present.
[07/18/2024 22:54:35] - Collecting drive data.
[07/18/2024 22:54:37] - ocp-smart-add-log is not supported on the drive nvme0n1 (WDC CL SN720 SDAQNTW-512G-1020).
[07/18/2024 22:54:40] - PASSED - 3 - Test drives list is not empty - Actual: [[nvme0n1]] - Validation: [isNonEmptyList] - Expected: [Non Empty List]
[07/18/2024 22:54:42] - Warning: Did not find UnsuppReg in lspci output, check the drive nvme0n1
[07/18/2024 22:54:44] - ocp-smart-add-log is not supported on the drive nvme0n1 (WDC CL SN720 SDAQNTW-512G-1020).
[07/18/2024 22:54:46] - ocp-smart-add-log is not supported on the drive nvme0n1 (WDC CL SN720 SDAQNTW-512G-1020).
[07/18/2024 22:54:46] - umount and remove raid devices
[07/18/2024 22:54:47] - Removing drive's partitions
[07/18/2024 22:54:54] - Skipping BMC-based SSD drive health checking
[07/18/2024 22:54:55] - PASSED - 4 - Run 'nvme id-ctrl /dev/nvme0n1 -H | grep -v fguid' - Actual: [None] - Validation: [isNotException] - Expected: [None]
[07/18/2024 22:54:55] - PASSED - 5 - nvme0n1: Crypto Erase Supported - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/18/2024 22:54:59] - PASSED - 6 - Drives supporting cache enable-disable - Actual: [[nvme0n1]] - Validation: [isNonEmptyList] - Expected: [Non Empty List]
[07/18/2024 22:55:09] - fio version on the host is 3.35 
[07/18/2024 22:55:09] - Expected fio version is 3.32 
[07/18/2024 22:55:09] - The fio version on the host is greater than the expected version
[07/18/2024 22:55:11] - Expected iops threshold 0.
[07/18/2024 22:55:11] - Expected iops diff threshold 0.2.
[07/18/2024 22:55:11] - Expected latency_100 threshold 100.
[07/18/2024 22:55:11] - PASSED - 7 - Fio setup() - Actual: [None] - Validation: [isNotException] - Expected: [None]
[07/18/2024 22:55:12] - Enabling cache
[07/18/2024 22:55:16] - Device nvme0n1 info: {'type': 'btrfs', '1b_blocks': 255784386560, 'used': 45033136128, 'available': 205871587328, 'use_pct': '18%', 'mounted_on': '/'}
[07/18/2024 22:55:16] - nvme0n1: size 100% is greater than 75% of available size
[07/18/2024 22:55:20] - Job file used: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/rtptest023.ldc1.facebook.com_write_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME1m_RWrandwrite_SIZE100%_VERIFYmd5.fio
[07/18/2024 22:55:20] - Starting fio on DUT
[07/18/2024 22:55:20] - Running write FIO command:  fio /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/rtptest023.ldc1.facebook.com_write_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME1m_RWrandwrite_SIZE100%_VERIFYmd5.fio --output-format=json --output=/home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:55:20.json
[07/18/2024 22:56:21] - FIO output file is copied at: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:55:20.json
[07/18/2024 22:56:21] - PASSED - 8 - Ran fio on /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:55:20.json - Actual: [True] - Validation: [isTrue] - Expected: [True]
/data/sandcastle/boxes/fbsource/buck-out/v2/gen/fbcode/5ce5662abd58612b/autoval/__autoval_test_runner__/autoval_test_runner#link-tree/paramiko/sftp_file.py:530: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
  t.setDaemon(True)
[07/18/2024 22:56:23] - Parsing results: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:55:20.json
[07/18/2024 22:56:23] - PASSED - 9 - Saved results for fio run - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/18/2024 22:56:23] - Compare write iops by model:
[07/18/2024 22:56:23] - PASSED - 10 -  compare by model - WDC CL SN720 SDAQNTW-512G-1020 has write iops: 1079 - Actual: [1079] - Validation: [isGreater] - Expected: [0]
[07/18/2024 22:56:23] - Checking latency_ms threshold by model
[07/18/2024 22:56:23] - PASSED - 11 -  compare by model: Validate if the WDC CL SN720 SDAQNTW-512G-1020 P100 value of latency_ms is less than 100 - Actual: [1.475605] - Validation: [isLess] - Expected: [100]
[07/18/2024 22:56:23] - Compare write iops by cycle:
[07/18/2024 22:56:23] - PASSED - 12 -  compare by cycle - /dev/nvme0n1 has write iops: 1079 - Actual: [1079] - Validation: [isGreater] - Expected: [0]
[07/18/2024 22:56:23] - Checking latency_ms threshold by cycle:
[07/18/2024 22:56:23] - PASSED - 13 -  compare by cycle: Validate if the /dev/nvme0n1 P100 value of latency_ms is less than 100 - Actual: [1.475605] - Validation: [isLess] - Expected: [100]
[07/18/2024 22:56:24] - Parsing results: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:55:20.json
[07/18/2024 22:56:31] - Job file used: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/rtptest023.ldc1.facebook.com_read_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME1m_RWrandread_SIZE100%_VERIFYmd5.fio
[07/18/2024 22:56:31] - Starting fio on DUT
[07/18/2024 22:56:31] - Running read FIO command:  fio /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/rtptest023.ldc1.facebook.com_read_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME1m_RWrandread_SIZE100%_VERIFYmd5.fio --output-format=json --output=/home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:31.json
[07/18/2024 22:56:34] - FIO output file is copied at: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:31.json
[07/18/2024 22:56:34] - PASSED - 14 - Ran fio on /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:31.json - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/18/2024 22:56:35] - Parsing results: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:31.json
[07/18/2024 22:56:35] - PASSED - 15 - Saved results for fio run - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/18/2024 22:56:35] - Compare read iops by model:
[07/18/2024 22:56:35] - PASSED - 16 -  compare by model - WDC CL SN720 SDAQNTW-512G-1020 has read iops: 32853 - Actual: [32853] - Validation: [isGreater] - Expected: [0]
[07/18/2024 22:56:35] - Checking latency_ms threshold by model
[07/18/2024 22:56:35] - PASSED - 17 -  compare by model: Validate if the WDC CL SN720 SDAQNTW-512G-1020 P100 value of latency_ms is less than 100 - Actual: [0.364271] - Validation: [isLess] - Expected: [100]
[07/18/2024 22:56:35] - Compare read iops by cycle:
[07/18/2024 22:56:35] - PASSED - 18 -  compare by cycle - /dev/nvme0n1 has read iops: 32853 - Actual: [32853] - Validation: [isGreater] - Expected: [0]
[07/18/2024 22:56:35] - Checking latency_ms threshold by cycle:
[07/18/2024 22:56:35] - PASSED - 19 -  compare by cycle: Validate if the /dev/nvme0n1 P100 value of latency_ms is less than 100 - Actual: [0.364271] - Validation: [isLess] - Expected: [100]
[07/18/2024 22:56:37] - Parsing results: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:31.json
[07/18/2024 22:56:37] - Disabling cache
[07/18/2024 22:56:43] - Job file used: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/rtptest023.ldc1.facebook.com_write_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME1m_RWrandwrite_SIZE100%_VERIFYmd5.fio
[07/18/2024 22:56:43] - Starting fio on DUT
[07/18/2024 22:56:43] - Running write FIO command:  fio /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/rtptest023.ldc1.facebook.com_write_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME1m_RWrandwrite_SIZE100%_VERIFYmd5.fio --output-format=json --output=/home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:43.json
[07/18/2024 22:57:45] - FIO output file is copied at: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:43.json
[07/18/2024 22:57:45] - PASSED - 20 - Ran fio on /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:43.json - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/18/2024 22:57:46] - Parsing results: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:43.json
[07/18/2024 22:57:46] - PASSED - 21 - Saved results for fio run - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/18/2024 22:57:46] - Compare write iops by model:
[07/18/2024 22:57:46] - PASSED - 22 -  compare by model - WDC CL SN720 SDAQNTW-512G-1020 has write iops: 956 - Actual: [956] - Validation: [isGreater] - Expected: [0]
[07/18/2024 22:57:46] - Checking latency_ms threshold by model
[07/18/2024 22:57:46] - PASSED - 23 -  compare by model: Validate if the WDC CL SN720 SDAQNTW-512G-1020 P100 value of latency_ms is less than 100 - Actual: [0.557365] - Validation: [isLess] - Expected: [100]
[07/18/2024 22:57:46] - Compare write iops by cycle:
[07/18/2024 22:57:46] - PASSED - 24 -  compare by cycle - /dev/nvme0n1 has write iops: 956 - Actual: [956] - Validation: [isGreater] - Expected: [0]
[07/18/2024 22:57:46] - Checking latency_ms threshold by cycle:
[07/18/2024 22:57:46] - PASSED - 25 -  compare by cycle: Validate if the /dev/nvme0n1 P100 value of latency_ms is less than 100 - Actual: [0.557365] - Validation: [isLess] - Expected: [100]
[07/18/2024 22:57:48] - Parsing results: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:56:43.json
[07/18/2024 22:57:54] - Job file used: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/rtptest023.ldc1.facebook.com_read_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME1m_RWrandread_SIZE100%_VERIFYmd5.fio
[07/18/2024 22:57:54] - Starting fio on DUT
[07/18/2024 22:57:54] - Running read FIO command:  fio /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/rtptest023.ldc1.facebook.com_read_cycle_0_BLKSIZE4k_DEPTH128_RUNTIME1m_RWrandread_SIZE100%_VERIFYmd5.fio --output-format=json --output=/home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:57:54.json
[07/18/2024 22:57:57] - FIO output file is copied at: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:57:54.json
[07/18/2024 22:57:57] - PASSED - 26 - Ran fio on /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:57:54.json - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/18/2024 22:57:59] - Parsing results: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:57:54.json
[07/18/2024 22:57:59] - PASSED - 27 - Saved results for fio run - Actual: [True] - Validation: [isTrue] - Expected: [True]
[07/18/2024 22:57:59] - Compare read iops by model:
[07/18/2024 22:57:59] - PASSED - 28 -  compare by model - WDC CL SN720 SDAQNTW-512G-1020 has read iops: 35201 - Actual: [35201] - Validation: [isGreater] - Expected: [0]
[07/18/2024 22:57:59] - Checking latency_ms threshold by model
[07/18/2024 22:57:59] - PASSED - 29 -  compare by model: Validate if the WDC CL SN720 SDAQNTW-512G-1020 P100 value of latency_ms is less than 100 - Actual: [0.0] - Validation: [isLess] - Expected: [100]
[07/18/2024 22:57:59] - Compare read iops by cycle:
[07/18/2024 22:57:59] - PASSED - 30 -  compare by cycle - /dev/nvme0n1 has read iops: 35201 - Actual: [35201] - Validation: [isGreater] - Expected: [0]
[07/18/2024 22:57:59] - Checking latency_ms threshold by cycle:
[07/18/2024 22:57:59] - PASSED - 31 -  compare by cycle: Validate if the /dev/nvme0n1 P100 value of latency_ms is less than 100 - Actual: [0.0] - Validation: [isLess] - Expected: [100]
[07/18/2024 22:58:00] - Parsing results: /home/manivelaarthi/autoval/logs/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/fio_rtptest023.ldc1.facebook.com_2024-07-18_22:57:54.json
[07/18/2024 22:58:00] - Drive /root/autoval_fio_file has read_iops enabled 32853 vs disabled cache 35201
[07/18/2024 22:58:00] - PASSED - 33 - Drive /root/autoval_fio_file write_iops enabled vs disabled cache - Actual: [1079] - Validation: [isGreaterOrEqual] - Expected: [956]
[07/18/2024 22:58:02] - PASSED - 34 - Asserting device names match - Actual: [['nvme0n1', 'nvme0n1p1', 'nvme0n1p2']] - Validation: [isEqual] - Expected: [['nvme0n1', 'nvme0n1p1', 'nvme0n1p2']]
[07/18/2024 22:58:05] - umount and remove raid devices
[07/18/2024 22:58:06] - Removing drive's partitions
[07/18/2024 22:58:12] - Removing all mounted path
[07/18/2024 22:58:12] - Validating umount all drives
[07/18/2024 22:58:12] - PASSED - 35 - Validating the unmount on drives - Actual: [[]] - Validation: [isEmptyList] - Expected: [[]]
[07/18/2024 22:58:17] - PASSED - 36 - Check available drives against initial list. - Actual: [['nvme0n1']] - Validation: [isEqual] - Expected: [['nvme0n1']]
[07/18/2024 22:58:27] - ocp-smart-add-log is not supported on the drive nvme0n1 (WDC CL SN720 SDAQNTW-512G-1020).
[07/18/2024 22:58:29] - ocp-smart-add-log is not supported on the drive nvme0n1 (WDC CL SN720 SDAQNTW-512G-1020).
[07/18/2024 22:58:31] - ocp-smart-add-log is not supported on the drive nvme0n1 (WDC CL SN720 SDAQNTW-512G-1020).
[07/18/2024 22:58:35] - Converting storage data for config check
[07/18/2024 22:58:38] - ocp-smart-add-log is not supported on the drive nvme0n1 (WDC CL SN720 SDAQNTW-512G-1020).
[07/18/2024 22:58:41] - saving config results from storage_test_base at /home/manivelaarthi/autoval/results/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/config_results.json
[07/18/2024 22:58:41] - saving results at /home/manivelaarthi/autoval/results/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/test_results.json
[07/18/2024 22:58:41] - saving test steps at /home/manivelaarthi/autoval/results/rtptest023.ldc1/DriveCacheCheck/2024-07-18_22-53-52/test_steps.json
[07/18/2024 22:58:41] - +++Test Finished:
Test Summary: DriveCacheCheck 
    This script is used to validate the performace of the SSD/HDD drive during a
    fio operation by disabling and enabling the internal volatile write cache
    by running the relavent commands on the drive. Parameters: Power-cycle: warm, State save before test: None,
Passed Steps: 44
Warning Steps: 0
Failed Steps: 0
Test Result : TEST PASSED

