### PR TITLE
Calling a run_fio method and load .job files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,4 @@ publish = ["build", "twine"]
 "Source" = "https://github.com/opencomputeproject/ocp-diag-autoval-ssd"
 
 [tool.setuptools.package-data]
-"*" = ["*.json", "*.fio"]
+"*" = ["*.json", "*.fio", "*.job"]

--- a/src/autoval_ssd/tests/drive_data_integrity/drive_data_integrity.py
+++ b/src/autoval_ssd/tests/drive_data_integrity/drive_data_integrity.py
@@ -575,6 +575,7 @@ class DriveDataIntegrityTest(StorageTestBase):
             fio_output_file = (
                 f"{self.fiolog_dir}/fio-cycle_{cycle}_{name}.log".format(cycle, name)
             )
+            self._run_fio_local(di_job, fio_output_file, power_trigger=power_trigger)
 
     def _run_fio_cmd(self, cmd: str, timeout: int, power_trigger: bool) -> None:
         """


### PR DESCRIPTION
In the drive_data_integrity.py file, a call to run_fio_local was missing after generating the fio_output file. This has been fixed by calling the method. Additionally, the jobfile_templates folder containing all .job files was missing from the code base, which has now been corrected.