### PR TITLE
Remove non-open-source dependency (fb-FioSynthFlash) from autoval_ssd

### DIFF
--- a/rpm_repo_hosting.md
+++ b/rpm_repo_hosting.md
@@ -51,13 +51,24 @@ mkdir -p /shared/autoval/pkgs/
 Download and copy RPMs into the repository directory based on test requirements.  We recommend the following (at a minimum):
 
 * ``smartmontools``
-* ``fb-FioSynthFlash``
+* ``fiosynth``
 * ``fio-engine-libaio``
 * ``fio``
 * ``hdparm``
 * ``libaio``
 * ``nvme-cli``
 * ``sdparm``
+
+#### Generate `fiosynth` rpm from source
+The following instructions can be used to build FioSynthFlash rpm from source (it is not generally pre-packaged as part linux OS distributions):
+
+```bash
+git clone https://github.com/facebookincubator/FioSynth
+cd FioSynth/
+sudo python3 setup.py bdist_rpm
+cd dist/
+```
+After the rpm is successfully built, you can upload it from the current directory to the RPM repository.
 
 > [!NOTE]
 > Specific versions of RPMs (e.g. ``fio`` or ``nvme-cli`` may be needed for specific tests or types of testing).

--- a/src/autoval_ssd/lib/utils/fio/fio_synth_flash_utils.py
+++ b/src/autoval_ssd/lib/utils/fio/fio_synth_flash_utils.py
@@ -43,29 +43,29 @@ class FioSynthFlashUtils:
 
     @staticmethod
     def tool_setup(host) -> None:
-        AutovalLog.log_info("Installing fb-FioSynthFlash")
-        SystemUtils.install_rpms(host, ["fb-FioSynthFlash"])
+        AutovalLog.log_info("Installing fiosynth")
+        SystemUtils.install_rpms(host, ["fiosynth"])
         FioSynthFlashUtils.get_version(host)
 
     @staticmethod
     def get_version(host) -> None:
-        out = host.run("fb-FioSynthFlash -v")
+        out = host.run("fiosynth -v")
         pattern = r"\d+\.\d+\.*\d*"
         match = re.search(pattern, out)
         if match:
             version = match.group(0)
-            AutovalLog.log_info("+++Running fb-FioSynthFlash version: %s" % version)
+            AutovalLog.log_info("+++Running fiosynth version: %s" % version)
         else:
-            AutovalLog.log_info("fb-FioSynthFlash version not detected: Reinstalling")
-            SystemUtils.install_rpms(host, ["fb-FioSynthFlash"], force_install=True)
-            out = host.run("fb-FioSynthFlash -v")
+            AutovalLog.log_info("fiosynth version not detected: Reinstalling")
+            SystemUtils.install_rpms(host, ["fiosynth"], force_install=True)
+            out = host.run("fiosynth -v")
             match2 = re.search(pattern, out)
             if match2:
                 version = match2.group(0)
-                AutovalLog.log_info("+++Running fb-FioSynthFlash version: %s" % version)
+                AutovalLog.log_info("+++Running fiosynth version: %s" % version)
             else:
                 raise TestError(
-                    "fb-FioSynthFlash version not detected: %s" % out,
+                    "fiosynth version not detected: %s" % out,
                     component=COMPONENT.STORAGE_DRIVE,
                     error_type=ErrorType.TOOL_ERR,
                 )
@@ -208,7 +208,7 @@ class FioSynthFlashUtils:
                 error_type=ErrorType.INPUT_ERR,
             )
         AutovalLog.log_info("[FioSynthFlash Log] Starting fioSynthFlash.")
-        cmd = "fb-FioSynthFlash -x -w %s" % workload
+        cmd = "fiosynth -x -w %s" % workload
         if raid:
             AutovalLog.log_info("[FioSynthFlash Log] Running in ALLRAID.")
             results_file = workload + "_raid_results"

--- a/src/autoval_ssd/tests/fio_synth_flash/fio_synth_flash.py
+++ b/src/autoval_ssd/tests/fio_synth_flash/fio_synth_flash.py
@@ -224,7 +224,7 @@ class FioSynthFlash(StorageTestBase):
         StorageUtils.change_nvme_io_timeout(
             host=self.host, test_phase="setup()", new_timeout=8
         )
-        self.storage_test_tools.extend(["fb-FioSynthFlash"])
+        self.storage_test_tools.extend(["fiosynth"])
         super().setup(*args, **kwargs)
         self.synth_result_dir = FioSynthFlashUtils.setup_synth_resultdir(
             self.host, self.dut_logdir[self.host.hostname]


### PR DESCRIPTION
fb-FioSynthFlash (which is a Meta-specific packaging of the open source [FioSynth].So, I modified autoval_ssd to use open source fiosynth instead of fb-FioSynthFlash and I provided instructions on how to build the fiosynth rpm from source.