### PR TITLE
Fix for cfg file changes in fio_synth_flash_utils file

### DIFF
--- a/src/autoval_ssd/lib/utils/fio/fio_synth_flash_utils.py
+++ b/src/autoval_ssd/lib/utils/fio/fio_synth_flash_utils.py
@@ -18,7 +18,7 @@ from autoval.lib.utils.autoval_log import AutovalLog
 from autoval.lib.utils.autoval_thread import AutovalThread
 from autoval.lib.utils.autoval_utils import AutovalUtils
 from autoval.lib.utils.file_actions import FileActions
-from autoval.lib.utils.generic_utils import GenericUtils
+from autoval_ssd.lib.utils.storage.nvme.nvme_drive import NVMeDrive
 from autoval_ssd.lib.utils.system_utils import SystemUtils
 
 
@@ -392,11 +392,8 @@ class FioSynthFlashUtils:
                 if drive.is_ocp_2_6_drive():
                     filename = "Workload_Loop_Targets_OCP2.6.json"
                     break
-        cfg_dir = "cfg"
-        relative_cfg_file_path = os.path.join(cfg_dir, filename)
-        benchmark_dict = GenericUtils.read_resource_cfg(
-            file_path=relative_cfg_file_path, module="autoval_ssd"
-        )
+        nvme_cfg_path = os.path.join(NVMeDrive.get_target_path(), "cfg", filename)
+        benchmark_dict = FileActions.read_data(nvme_cfg_path, json_file=True)
         csv_files = ""
         fio_results_dir = FioSynthFlashUtils.find_file_paths(
             host, results_dir, file_extension=""

--- a/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
+++ b/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
@@ -148,7 +148,8 @@ class NVMeDrive(Drive):
         }
         return validate_config
 
-    def get_target_path(self) -> str:
+    @staticmethod
+    def get_target_path() -> str:
         """
         Returns the path of the target path which is used to get the cfg path in the autoval-oss
         """


### PR DESCRIPTION
The current implementation of read_resource_cfg() does not support the ocp-diag_autoval-ssd package due to the following reason: When installing packages using pip, the default installation location for packages in Python 3.9 on Linux systems is /usr/local/lib/python3.9/site-packages/. Consequently, the pkg_resources.resource_filename() method returns a path to the package resources within this directory, which differs from the actual location of the configuration file in the autoval-ssd folder.
To address this issue, this changes fixes a configuration issue in the fio_synth_flash_utils file.
