### PR TITLE
Fix for config fio_fb_perf

### DIFF
--- a/src/autoval_ssd/lib/utils/jobfile_templates/random_job.fio
+++ b/src/autoval_ssd/lib/utils/jobfile_templates/random_job.fio
@@ -11,5 +11,6 @@ time_based
 refill_buffers
 runtime=RUNTIME
 rw=RW
-rwmixread=RWMIX
+rwmixread=MIXREAD
+rwmixwrite=MIXWRITE
 bs=BLKSIZE

--- a/src/autoval_ssd/tests/fio_fb/fio_fb_perf.json
+++ b/src/autoval_ssd/tests/fio_fb/fio_fb_perf.json
@@ -19,7 +19,8 @@
             "precondition_template": "random_precondition.fio",
             "args": {
                 "RUNTIME": "1200s",
-                "RWMIX": [0, 70, 100],
+                "MIXREAD": 70,
+                "MIXWRITE": 30,
                 "BLKSIZE": ["256k", "512k"],
                 "IODEPTH": ["1", "4", "8", "16"],
                 "NUM_JOBS": ["1", "4", "8"],


### PR DESCRIPTION
Fix FioFb with random_job.fio jobfile

Prior to this commit, running FioFb with any control file
(e.g. fio_fb_perf.json) referencing random_job.fio would fail with the
following error:

    [AUTOVAL TOOL ERROR] Error in starting fio job. Reason: fio:
    failed parsing rwmixread=randrwMIX 585fio: job global dropped

There were two problems with the previous code:

1. The rwmixread fio job parameter accepts an integer, but the RWMIX
   was defined as an array of strings.

2. It is invalid for one macro name to be a prefix of another (e.g. RW
   is a prefix of RWMIX).  In the case where this happens, only the
   prefix part of the macro is expanded (e.g. RWMIX expands to
   randrMIX instead of [0. 70, 100] because RW is a prefix of RWMIX)

This commit addresses both issues.