### PR TITLE
Add support for new version of nvme-cli v2.8

### DIFF
--- a/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
+++ b/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
@@ -515,18 +515,28 @@ class NVMeDrive(Drive):
                     result[k] = v
         return {"ocp-smart-add-log": result}
 
-    def get_internal_log(self) -> bool:
-        """Return drive internal log.
+    def get_ocp_telemetry_string_log(self) -> None:
+        """
+        Retrieves and stores the OCP telemetry log from a specified NVMe drive.
         Args:
-        ----
-        None
-
+            None
         Returns:
-        -------
-        bool: The completion status of internal log file generation.
+            None
         """
         dut_logdir = SiteUtils.get_dut_logdir(self.host.hostname)
-        cmd = "nvme ocp internal-log /dev/%s" % self.block_name
+        cmd = f"nvme ocp telemetry-string-log /dev/{self.block_name}"
+        self.host.run(cmd=cmd, ignore_status=True, working_directory=dut_logdir)
+
+    def get_internal_log(self) -> bool:
+        """
+        Return drive telemetry log.
+        Args:
+            None
+        Returns:
+            The completion status of internal log file generation.
+        """
+        dut_logdir = SiteUtils.get_dut_logdir(self.host.hostname)
+        cmd = f"nvme telemetry-log --output-file=bin /dev/{self.block_name}"
         ret = self.host.run_get_result(
             cmd=cmd, ignore_status=True, working_directory=dut_logdir
         )
@@ -1342,28 +1352,19 @@ class NVMeDrive(Drive):
         This method sets the value of the power mode using
         the power management feature of the drive.
 
-        Returns
-        -------
-        feature_value : String
-            Set feature value that gives current power-mode of
-            the drive. Eg: "5".
+        Args:
+            feature_value: target power-mode of the drive. Eg: `5`.
 
-        Raises
-        ------
-        TestError
-            - When fails to set the power mode.
-            - When fails to match the set-feature output with the
-              given pattern.
-        NotImplementedError
-            - When the power mode is not supported by the drive.
+        Raises:
+            TestError
+                - When fails to set the power mode.
+                - When fails to match the set-feature output with the
+                  given pattern
         """
-
-        cmd = "nvme set-feature /dev/%s -f 0x2 -v %s" % (
-            self.block_name,
-            feature_value,
-        )
-        out = self.host.run(cmd=cmd)  # noqa
-        match = re.search(r"value:\s*(\S+)", out)
+        block_name = re.sub(r"(n\d+)(p\d+)?", "", self.block_name)
+        cmd = f"nvme set-feature /dev/{block_name} -f 0x2 --value {feature_value}"
+        out = self.host.run(cmd=cmd)
+        match = re.search(r"value:\s*(\w+)", out)
         if match:
             if int(match.group(1), 16) == feature_value:
                 return feature_value

--- a/src/autoval_ssd/lib/utils/storage/nvme/nvme_utils.py
+++ b/src/autoval_ssd/lib/utils/storage/nvme/nvme_utils.py
@@ -250,7 +250,7 @@ class NVMeUtils:
         match = re.search(r"(nvme\d+)", str(drive))
         if match:
             device = match.group(1)
-        cmd = "nvme set-feature /dev/%s -f 0x6 -v 1" % device
+        cmd = "nvme set-feature /dev/%s -f 0x6 --value 1" % device
         out = host.run(cmd, ignore_status=True)
         if "not support" in out:
             AutovalLog.log_info(f"Enable write_cache not supported on {drive}: {out}")
@@ -266,7 +266,7 @@ class NVMeUtils:
         match = re.search(r"(nvme\d+)", str(drive))
         if match:
             device = match.group(1)
-        cmd = "nvme set-feature /dev/%s -f 0x6 -v 0" % device
+        cmd = "nvme set-feature /dev/%s -f 0x6 --value 0" % device
         out = host.run(cmd, ignore_status=True)
         if "not support" in out:
             AutovalLog.log_info(f"Disable write_cache not supported on {drive}: {out}")
@@ -530,7 +530,7 @@ class NVMeUtils:
         @param: string : drive
         @return integer
         """
-        cmd = "nvme set-feature /dev/%s -f 0x10 -v %s" % (drive, hex(updated_tmt))
+        cmd = "nvme set-feature /dev/%s -f 0x10 --value %s" % (drive, hex(updated_tmt))
         output = host.run(cmd, ignore_status=True)
         if "INVALID_FIELD" not in output:
             return True

--- a/src/autoval_ssd/tests/nvme_cli/nvme_cli.py
+++ b/src/autoval_ssd/tests/nvme_cli/nvme_cli.py
@@ -20,7 +20,7 @@ from autoval_ssd.lib.utils.storage.storage_test_base import StorageTestBase
 
 class NvmeCli(StorageTestBase):
     """
-    Test to validate if NVME 1.2.1 spec commands are supported
+    Test to validate if NVME spec commands are supported
     Validations done on all the NVME drives:
         Get the controller properties,
         Get the Firmware Log,
@@ -73,6 +73,7 @@ class NvmeCli(StorageTestBase):
         self._get_id_ns(drive)
         self._get_feature(drive)
         self._get_internal_log(drive)
+        drive.get_ocp_telemetry_string_log()
         self._get_effects_log(drive)
         self._get_vs_timestamp(drive)
         self._validate_power_mode(drive)

--- a/src/autoval_ssd/tests/nvme_cli/nvme_cli_with_nvme_version.json
+++ b/src/autoval_ssd/tests/nvme_cli/nvme_cli_with_nvme_version.json
@@ -2,5 +2,6 @@
     "drive_type": "ssd",
     "drive_interface": "nvme",
     "include_boot_drive": true,
-    "nvme_version": "nvme-cli-2.6-4.el9.x86_64"
+    "boot_drive_physical_location": "0000:01:00.0",
+    "nvme_version" : "nvme-cli-2.8-1.hs.el9"
 }

--- a/src/autoval_ssd/unittest/test_nvme_drive.py
+++ b/src/autoval_ssd/unittest/test_nvme_drive.py
@@ -689,7 +689,7 @@ class NvmeDriveUnitTest(unittest.TestCase):
     @apply_mock
     def test_set_power_mode(self):
         feature = 1
-        cmd = f"nvme set-feature /dev/{self.mock_block_name} -f 0x2 -v {feature}"
+        cmd = f"nvme set-feature /dev/{self.mock_block_name} -f 0x2 --value {feature}"
         mock_output_valid = "set-feature:01 (Power Management), value:0x000001"
         mock_output_invalid = ""
         self.update_cmd_map(cmd, mock_output_valid)


### PR DESCRIPTION
Adds support for the new version of nvme-cli v2.8. The changes include updates to the nvme_utils.py file to use the new command format for setting the write_cache feature, and updates to the nvme_drive.py file to retrieve and store the OCP telemetry log. The test_nvme_drive.py file has also been updated to use the new command format for setting the power mode feature. The nvme_cli.py file has been updated to include the new OCP telemetry log retrieval method. Finally, the nvme_cli_with_nvme_version.json file has been updated to include the new nvme-cli version.
