### PR TITLE
drive_data_integrity: fix missing initialization

### DIFF
--- a/src/autoval_ssd/tests/drive_data_integrity/drive_data_integrity.py
+++ b/src/autoval_ssd/tests/drive_data_integrity/drive_data_integrity.py
@@ -115,6 +115,7 @@ class DriveDataIntegrityTest(StorageTestBase):
         self.stop_fio_process_check = False
         self.control_server_logs = SiteUtils.get_control_server_logdir()
         self.fiolog_server_dir = None
+        self.fio_process_queue = []
 
     def setup(self, *args, **kwargs) -> None:
         """Prerequisite for drive data integrity test.


### PR DESCRIPTION
Add fio_process_queue attribute initialize in __init__

Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval/autoval_test_runner.py", line 233, in <module>
    main()
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval/autoval_test_runner.py", line 229, in main
    AutoValTestRunner(autoval_cli()).main()
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval/autoval_test_runner.py", line 173, in main
    obj.lifecycle()
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval/lib/test_base.py", line 153, in lifecycle
    self._setup_execute_teardown()
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval/lib/test_base.py", line 220, in _setup_execute_teardown
    self._teardown()
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval/lib/test_base.py", line 45, in wrapper
    self._handle_exception(e)
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval/lib/test_base.py", line 43, in wrapper
    func(self, *args, **kwargs)
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval/lib/test_base.py", line 383, in _teardown
    self.cleanup()
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval_ssd/tests/drive_data_integrity/drive_data_integrity.py", line 1015, in cleanup
    self.stop_fio_monitor()
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval_ssd/tests/drive_data_integrity/drive_data_integrity.py", line 438, in stop_fio_monitor
    if len(self.fio_process_queue):
  File "/south/repo/ocp-diag-autoval-ssd/lib64/python3.9/site-packages/autoval/lib/test_base.py", line 491, in __getattr__
    return getattr(AutovalUtils, name)
AttributeError: type object 'AutovalUtils' has no attribute 'fio_process_queue'