### PR TITLE
nvme_format: fix wrong template file name

### DIFF
--- a/src/autoval_ssd/tests/nvme_format/control_nvme_sanity_check.json
+++ b/src/autoval_ssd/tests/nvme_format/control_nvme_sanity_check.json
@@ -8,7 +8,7 @@
     "secure_erase_option": [0, 1],
     "run_definition": {
       "filesystem_io": {
-        "template": "filesystem_template.job",
+        "template": "nvme_format_template.fio",
         "args": {
             "NAME": "fio_nvme",
             "RW": "write",


### PR DESCRIPTION
Fix wrong exmaple of control file
if the given template is used, below error occured from test (Failed to override template arguments from control file args)

[04/01/2025 19:54:53] - FAILED - 8 - Fio start_test() - Actual: [
ToolError: [AUTOVAL TOOL ERROR] Error in starting fio job. Reason:  fio: failed parsing size=SIZE
fio: failed parsing rwmixwrite=MIXWRITE
fio: failed parsing rwmixread=MIXREAD
fio: job global dropped