### PR TITLE
using nvme char dev

### DIFF
--- a/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
+++ b/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
@@ -211,8 +211,9 @@ class NVMeDrive(Drive):
         """
         Method to get the controller properties
         """
-        nvme_drive = "/dev/%s" % self.block_name
-        cmd = "nvme show-regs %s -H" % nvme_drive
+        pattern = re.compile(r'^(nvme\d+)(?=n)')
+        char_name = pattern.match(self.block_name).group(1)
+        cmd = "nvme show-regs /dev/%s -H" % char_name
         out = AutovalUtils.validate_no_exception(
             self.host.run,
             [cmd],

--- a/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
+++ b/src/autoval_ssd/lib/utils/storage/nvme/nvme_drive.py
@@ -550,7 +550,9 @@ class NVMeDrive(Drive):
         TestStepError
             When fails to retrieve the command effects log.
         """
-        cmd = "nvme effects-log /dev/%s -o json" % self.block_name
+        pattern = re.compile(r'^(nvme\d+)(?=n)')
+        char_name = pattern.match(self.block_name).group(1)
+        cmd = "nvme effects-log /dev/%s -o json" % char_name
         out = self.host.run(cmd=cmd)
         return json.loads(out)
 


### PR DESCRIPTION
effects-log and show-regs require nvme character device

**effets-log**
When using the "effects-log" command in nvme-cli without specifying the "csi" argument,
a default action is added to check the ctrl register,
allowing only character devices like nvme0.

In older versions of nvme-cli, the default value of csi was set to 0 and issued without any problems
But it has been fixed now.
It can be used regardless of the version when used as a character device.

**show-regs**
The documentation says:
The <device> parameter is mandatory and must be the nvme admin character device (ex: /dev/nvme0)

Reference:
https://github.com/linux-nvme/nvme-cli/pull/2742