### PR TITLE
Fix nvme-cli csts parsing for hexadecimal output

### DIFF
--- a/src/autoval_ssd/tests/nvme_cli/nvme_cli.py
+++ b/src/autoval_ssd/tests/nvme_cli/nvme_cli.py
@@ -106,9 +106,9 @@ class NvmeCli(StorageTestBase):
                     error_type=ErrorType.DRIVE_ERR,
                 )
             # Check csts
-            csts_match = re.search(r"csts\s+:\s+(\d+)", out)
+            csts_match = re.search(r"csts\s+:\s+(0x[0-9a-fA-F]+|\d+)", out)
             if csts_match:
-                csts = int(csts_match.group(1))
+                csts = int(csts_match.group(1), 0)
                 AutovalUtils.validate_equal(
                     csts,
                     1,


### PR DESCRIPTION
Some control files use nvme-cli version 2.6.4,
where the csts value is output as "csts : 1" even though it represents a hexadecimal value (%x format). Later versions and the latest release output the value with a "0x" prefix (e.g., "csts : 0x1").

Update the parser to correctly interpret the csts value as hexadecimal regardless of the format.