### PR TITLE
Fix OACS Device Self-Test capability detection

### DIFF
--- a/src/autoval_ssd/tests/nvme_cli/nvme_cli.py
+++ b/src/autoval_ssd/tests/nvme_cli/nvme_cli.py
@@ -505,11 +505,15 @@ class NvmeCli(StorageTestBase):
         Returns:
             The oacs value of the drive as a dict.
         """
+        # NVMe OACS bit 4 indicates Device Self-Test command support.
+        DEVICE_SELF_TEST_OACS_BIT = 4
+        DEVICE_SELF_TEST_OACS_MASK = 1 << DEVICE_SELF_TEST_OACS_BIT
+
         oacs = NVMeUtils.get_id_ctrl(self.host, drive.block_name)["oacs"]
         self.log_info(f"Test to Check dev_self_test management {oacs} {hex(oacs)}")
-        support_dev_self_test_management = oacs & 0x8
+        support_dev_self_test_management = bool(oacs & DEVICE_SELF_TEST_OACS_MASK)
         AutovalUtils.validate_condition(
-            support_dev_self_test_management == 0x8,
+            support_dev_self_test_management,
             f"Check dev_self_test management support SELF_TEST supported on /dev/{drive}",
             warning=True,
             log_on_pass=True,


### PR DESCRIPTION
## Summary

The NVMe specification defines Device Self-Test support at OACS bit 4 (`0x10`). The existing implementation checks bit 3 (`0x08`), which corresponds to Namespace Management.

This can produce false negatives when bit 4 is set and bit 3 is clear, such as with `OACS = 0x17`.

This change:

- checks OACS bit 4 for Device Self-Test support
- replaces the magic hexadecimal mask with named bit/mask constants
- improves readability of the capability check

Fixes #3

## Validation

Tested on:

- Device: `CT2000T500SSD8`
- Firmware: `P8CR002`
- nvme-cli: `2.16`
- OACS: `0x17`

The controller reports:

```bash
nvme id-ctrl -H /dev/nvme1n1 | grep oacs -A 11
```
```text
oacs : 0x17
[4:4] : 0x1  Device Self-test Supported
[3:3] : 0    NS Management and Attachment Not Supported
```
Relevant capability bits:

- Bit 3 = `0`: Namespace Management not supported
- Bit 4 = `1`: Device Self-Test supported

Before this change, AutoVal checks `0x08` (bit 3) and reports:

```text
WARNING: SELF_TEST supported on /dev/nvme1n1 - Actual: False
```

After this change, AutoVal checks `0x10` (bit 4),and the same device is correctly detected as supporting Device Self-Test.
```text
SELF_TEST supported on /dev/nvme1n1 - Actual: [True] - Validation: [isTrue] - Expected: [True]
```